### PR TITLE
Update format of README.md for meet github's markdown standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#README -- Ubuntu Dialogue Corpus v2.0
+# README -- Ubuntu Dialogue Corpus v2.0
 
 We describe the files for generating the Ubuntu Dialogue Corpus, and the dataset itself.
 
-##UPDATES FROM UBUNTU CORPUS v1.0:
+## UPDATES FROM UBUNTU CORPUS v1.0:
 
 There are several updates and bug fixes that are present in v2.0. The updates are significant enough that results on the two datasets will not be equivalent, and should not be compared. However, models that do well on the first dataset should transfer to the second dataset (with perhaps a new hyperparameter search).
 
@@ -12,19 +12,19 @@ There are several updates and bug fixes that are present in v2.0. The updates ar
 - Added differentiation between the end of an utterance (`__eou__`) and end of turn (`__eot__`). In the original dataset, we concatenated all consecutive utterances by the same user in to one utterance, and put `__EOS__` at the end. Here, we also denote where the original utterances were (with `__eou__`). Also, the terminology should now be consistent between the training and test set (instead of both `__EOS__` and `</s>`).
 - Fixed a bug that caused the distribution of false responses in the test and validation sets to be different from the true responses. In particular, the number of words in the false responses was shorter on average than for the true responses, which could have been exploited by some models.
 
-##UBUNTU CORPUS GENERATION FILES:
+## UBUNTU CORPUS GENERATION FILES:
 
-###generate.sh:
-####DESCRIPTION:
+### generate.sh:
+#### DESCRIPTION:
 Script that calls `create_ubuntu_dataset.py`. This is the script you should run in order to download the dataset. The parameters passed to this script will be passed to `create_ubuntu_dataset.py`. Example usage: `./generate.sh -t -s -l`.
 
-###create_ubuntu_dataset.py:
-####DESCRIPTION:
+### create_ubuntu_dataset.py:
+#### DESCRIPTION:
 Script for generation of train, test and valid datasets from Ubuntu Corpus 1 on 1 dialogs.
 The script downloads 1on1 dialogs from internet and then it randomly samples all the datasets with positive and negative examples.
 Copyright IBM 2015
 
-####ARGUMENTS:
+#### ARGUMENTS:
 - `--data_root`: directory where 1on1 dialogs will downloaded and extracted, the data will be downloaded from [cs.mcgill.ca/~jpineau/datasets/ubuntu-corpus-1.0/ubuntu_dialogs.tgz](http://cs.mcgill.ca/~jpineau/datasets/ubuntu-corpus-1.0/ubuntu_dialogs.tgz) (default = '.')
 - `--seed`: seed for random number generator (default = 1234)
 - `-o`, `--output`: output file for writing to csv (default = None)
@@ -34,7 +34,7 @@ Copyright IBM 2015
 
 *Note:* if both `-s` and `-l` are present, the stemmer is applied before the lemmatizer.
 
-####Subparsers:
+#### Subparsers:
 `train`: train set generator
 - `-p`: positive example probability, ie. the ratio of positive examples to total examples in the training set (default = 0.5)
 - `-e`, `--examples`: number of training examples to generate. Note that this will generate slightly fewer examples than desired, as there is a 'post-processing' step that filters  (default = 1000000)
@@ -46,25 +46,25 @@ Copyright IBM 2015
 - `-n`: number of distractor examples for each context (default = 9)
 
 
-###meta folder: trainfiles.csv, valfiles.csv, testfiles.csv:
-####DESCRIPTION:
+### meta folder: trainfiles.csv, valfiles.csv, testfiles.csv:
+#### DESCRIPTION:
 Maps the original dialogue files to the training, validation, and test sets.
 
 
-##UBUNTU CORPUS FILES (after generating):
+## UBUNTU CORPUS FILES (after generating):
 
-###train.csv:
+### train.csv:
 Contains the training set. It is separated into 3 columns: the context of the conversation, the candidate response or 'utterance', and a flag or 'label' (= 0 or 1) denoting whether the response is a 'true response' to the context (flag = 1), or a randomly drawn response from elsewhere in the dataset (flag = 0). This triples format is described in the paper. When generated with the default settings, train.csv is 463Mb, with 1,000,000 lines (ie. examples, which corresponds to 449,071 dialogues) and with a vocabulary size of ~~1,344,621~~. Note that, to generate the full dataset, you should use the `--examples` argument for the `create_ubuntu_dataset.py` file.
 
-###valid.csv:
+### valid.csv:
 Contains the validation set. Each row represents a question. Separated into 11 columns: the context, the true response or 'ground truth utterance', and 9 false responses or 'distractors' that were randomly sampled from elsewhere in the dataset. Your model gets a question correct if it selects the ground truth utterance from amongst the 10 possible responses. When generated with the default settings, `valid.csv` is 27Mb, with 19,561 lines and a vocabulary size of 115,688.
 
-###test.csv:
+### test.csv:
 Contains the test set. Formatted in the same way as the validation set. When generated with the default settings, test.csv is 27Mb, with 18,921 lines and a vocabulary size of 115,623.
 
-##BASELINE RESULTS
+## BASELINE RESULTS
 
-####Dual Encoder LSTM model:
+#### Dual Encoder LSTM model:
 ```
 1 in 2:
 	recall@1: 0.868730970907
@@ -74,7 +74,7 @@ Contains the test set. Formatted in the same way as the validation set. When gen
 	recall@5: 0.924285351827 
 ```
 
-####Dual Encoder RNN model:
+#### Dual Encoder RNN model:
 ```
 1 in 2:
 	recall@1: 0.776539210705,
@@ -84,7 +84,7 @@ Contains the test set. Formatted in the same way as the validation set. When gen
 	recall@5: 0.836350355691,
 ```
 
-####TF-IDF model:
+#### TF-IDF model:
 ```
 1 in 2:
 	recall@1:  0.749260042283
@@ -94,11 +94,11 @@ Contains the test set. Formatted in the same way as the validation set. When gen
 	recall@5:  0.763054968288
 ```
 
-##HYPERPARAMETERS USED
+## HYPERPARAMETERS USED
 
 Code for the model can be found here (might not be up to date with the new dataset): https://github.com/npow/ubottu
 
-####Dual Encoder LSTM model:
+#### Dual Encoder LSTM model:
 ```
 act_penalty=500
 batch_size=256
@@ -128,7 +128,7 @@ use_pv=False
 xcov_penalty=0.0
 ```
 
-####Dual Encoder RNN model:
+#### Dual Encoder RNN model:
 ```
 act_penalty=500
 batch_size=512

--- a/src/download_punkt.py
+++ b/src/download_punkt.py
@@ -1,0 +1,5 @@
+import nltk
+
+
+nltk.download('punkt')
+nltk.download('wordnet')

--- a/src/generate.sh
+++ b/src/generate.sh
@@ -1,3 +1,8 @@
+#!/usr/bin/env bash
+
+# download punkt first
+python download_punkt.py
+
 python create_ubuntu_dataset.py "$@" --output 'train.csv' 'train'
 python create_ubuntu_dataset.py "$@" --output 'test.csv' 'test'
 python create_ubuntu_dataset.py "$@" --output 'valid.csv' 'valid'


### PR DESCRIPTION
Currently README.md is not displayed correctly caused by document's format. Here, I update the format, Github can correctly render the document now.